### PR TITLE
Update project dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dmg"
 version = "0.1.1"
+edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Maciej Goszczycki <mgoszcz2@gmail.com>"]
 readme = "README.md"
@@ -11,11 +12,11 @@ documentation = "https://docs.rs/dmg/"
 keywords = ["dmg", "file", "mount", "osx"]
 
 [dependencies]
-plist = { version = "0.2.2", default-features = false }
-log = "0.3.8"
+plist = { version = "1.3.1", default-features = false }
+log = "0.4.17"
 
 [dev-dependencies]
-env_logger = "0.4.3"
+env_logger = "0.10.0"
 
 [[bin]]
 name = "demo"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,17 +42,14 @@
 //! [1]: https://github.com/mgoszcz2/dmg/blob/master/src/tests.rs
 //! [2]: https://github.com/mgoszcz2/dmg/blob/master/src/bin/demo.rs
 
-extern crate plist;
-#[macro_use]
-extern crate log;
-
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::io::{self, ErrorKind, Cursor};
 use std::ops::Deref;
 use std::env;
 
-use plist::Plist;
+use log::info;
+use plist::Value;
 
 #[cfg(test)]
 mod tests;
@@ -225,7 +222,7 @@ impl Attach {
             return Err(io::Error::new(ErrorKind::Other, "hdiutil failed"));
         }
 
-        if let Ok(plist) = Plist::read(Cursor::new(output.stdout)) {
+        if let Ok(plist) = Value::from_reader(Cursor::new(output.stdout)) {
             let entities = check!(check!(check!(plist.as_dictionary()).get("system-entities")).as_array());
             for entity in entities {
                 let properties = check!(entity.as_dictionary());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate env_logger;
-
 use std::fs::File;
 
 use super::*;
@@ -17,7 +15,7 @@ const ERRRNO_EROFS: i32 = 30;
 
 macro_rules! logger {
     () => {
-        let _ =env_logger::init();
+        let _ = env_logger::builder().is_test(true).try_init();
     }
 }
 


### PR DESCRIPTION
This PR updates project dependencies to their latest versions. The project currently depends on `plist` `0.2.2` which depends on a lot of other outdated libraries, which causes duplicate library compilation and [potential security problems](https://github.com/advisories/GHSA-wcg3-cvx6-7396).